### PR TITLE
Crazoonga Improvements

### DIFF
--- a/SideStep Crazoonga Hours/Scenes/PickupShell.tscn
+++ b/SideStep Crazoonga Hours/Scenes/PickupShell.tscn
@@ -3,6 +3,9 @@
 [ext_resource type="Script" path="res://Scripts/Pickup.gd" id="1_jtwhv"]
 [ext_resource type="PackedScene" uid="uid://dnqhbphlgpnlx" path="res://Models/Shell_A.glb" id="2_v4rbj"]
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_3ddsh"]
+size = Vector3(0.239795, 0.147228, 0.253969)
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_c5614"]
 albedo_color = Color(0.552941, 0.231373, 0.117647, 1)
 
@@ -28,15 +31,17 @@ _data = {
 "ShellSpin": SubResource("Animation_d0aur")
 }
 
-[sub_resource type="BoxShape3D" id="BoxShape3D_3ddsh"]
-size = Vector3(0.239795, 0.147228, 0.253969)
-
-[node name="Shell" type="Node3D" groups=["shells"]]
-transform = Transform3D(8.86889, 0, 0, 0, 8.86889, 0, 0, 0, 8.86889, 0, 0.20499, 0)
+[node name="Area3D" type="Area3D" groups=["shells"]]
+collision_layer = 16
+collision_mask = 2
 script = ExtResource("1_jtwhv")
 
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.135214, 0)
+shape = SubResource("BoxShape3D_3ddsh")
+
 [node name="Shell_A" parent="." instance=ExtResource("2_v4rbj")]
-transform = Transform3D(0.0891824, -0.0238963, 0, 0.0238963, 0.0891824, 0, 0, 0, 0.0923284, 0, -0.0928991, 0)
+transform = Transform3D(0.0965926, -0.0258819, 0, 0.0258819, 0.0965926, 0, 0, 0, 0.1, 0, -0.0396624, 0)
 
 [node name="Shell A" parent="Shell_A" index="0"]
 material_override = SubResource("StandardMaterial3D_c5614")
@@ -46,15 +51,5 @@ autoplay = "ShellSpin"
 libraries = {
 "": SubResource("AnimationLibrary_skqbf")
 }
-
-[node name="Area3D" type="Area3D" parent="."]
-collision_layer = 16
-collision_mask = 2
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0960752, 0)
-shape = SubResource("BoxShape3D_3ddsh")
-
-[connection signal="body_entered" from="Area3D" to="." method="_on_area_3d_body_entered"]
 
 [editable path="Shell_A"]

--- a/SideStep Crazoonga Hours/Scenes/crazoonga.tscn
+++ b/SideStep Crazoonga Hours/Scenes/crazoonga.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=3 uid="uid://dsn5l2kp7qlq1"]
+[gd_scene load_steps=27 format=3 uid="uid://dsn5l2kp7qlq1"]
 
 [ext_resource type="Script" path="res://Scripts/Crazoonga.gd" id="1_na1ic"]
 [ext_resource type="AudioStream" uid="uid://ywm3hfex44xo" path="res://Audio/claw snap.ogg" id="2_abk3g"]
@@ -315,21 +315,21 @@ length = 0.1
 tracks/0/type = "rotation_3d"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Armature/Skeleton3D:Claw Base R")
+tracks/0/path = NodePath("Skeleton3D:Claw Base R")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = PackedFloat32Array(0, 1, -0.505941, -0.0259253, 0.218782, 0.833958)
 tracks/1/type = "rotation_3d"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("Armature/Skeleton3D:Claw Mid R")
+tracks/1/path = NodePath("Skeleton3D:Claw Mid R")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = PackedFloat32Array(0, 1, -0.763587, 0.473159, -0.334548, 0.28484)
 tracks/2/type = "rotation_3d"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("Armature/Skeleton3D:Claw Bottom R")
+tracks/2/path = NodePath("Skeleton3D:Claw Bottom R")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = PackedFloat32Array(0, 1, 0.0390122, 0.0785491, -0.0139432, 0.996049)
@@ -340,28 +340,28 @@ length = 0.5
 tracks/0/type = "rotation_3d"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Armature/Skeleton3D:Claw Base R")
+tracks/0/path = NodePath("Skeleton3D:Claw Base R")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = PackedFloat32Array(0.0333333, 1, -0.505941, -0.0259253, 0.218782, 0.833958, 0.0666667, 1, -0.467421, 0.118316, 0.264543, 0.835186, 0.1, 1, -0.398533, 0.305553, 0.315358, 0.805207, 0.133333, 1, -0.344835, 0.43508, 0.342289, 0.758045, 0.166667, 1, -0.382388, 0.42403, 0.332632, 0.750556, 0.2, 1, -0.471987, 0.393785, 0.306476, 0.726797, 0.233333, 1, -0.57003, 0.353603, 0.272163, 0.689897, 0.266667, 1, -0.656216, 0.310748, 0.235949, 0.645867, 0.3, 1, -0.716909, 0.275148, 0.206094, 0.606515, 0.4, 1, -0.505941, -0.0259253, 0.218782, 0.833958)
 tracks/1/type = "rotation_3d"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("Armature/Skeleton3D:Claw Mid R")
+tracks/1/path = NodePath("Skeleton3D:Claw Mid R")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = PackedFloat32Array(0.0333333, 1, -0.763587, 0.473159, -0.334548, 0.28484, 0.0666667, 1, -0.636545, 0.455464, -0.387953, 0.486678, 0.1, 1, -0.406655, 0.3902, -0.423208, 0.709416, 0.133333, 1, -0.198955, 0.317032, -0.418644, 0.827433, 0.166667, 1, -0.188007, 0.332238, -0.413251, 0.826737, 0.2, 1, -0.180153, 0.367931, -0.397977, 0.820845, 0.233333, 1, -0.174051, 0.408052, -0.379391, 0.81195, 0.266667, 1, -0.169519, 0.445566, -0.360749, 0.80162, 0.3, 1, -0.166579, 0.474095, -0.345738, 0.792433, 0.4, 1, -0.763587, 0.473159, -0.334548, 0.28484)
 tracks/2/type = "rotation_3d"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("Armature/Skeleton3D:Claw Bottom R")
+tracks/2/path = NodePath("Skeleton3D:Claw Bottom R")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = PackedFloat32Array(0.0333333, 1, 0.0390122, 0.0785491, -0.0139432, 0.996049, 0.0666667, 1, 0.0510466, 0.07177, -0.0213703, 0.995885, 0.1, 1, 0.0670725, 0.0627039, -0.0312647, 0.995285, 0.133333, 1, 0.0785462, 0.056712, -0.0358999, 0.994649, 0.166667, 1, 0.0764321, 0.06001, -0.0247898, 0.994959, 0.2, 1, 0.071336, 0.0678594, 0.00177993, 0.99514, 0.233333, 1, 0.065424, 0.0767918, 0.0322381, 0.994376, 0.266667, 1, 0.0596997, 0.0852688, 0.0613682, 0.992673, 0.3, 1, 0.0552033, 0.0918127, 0.0840085, 0.99069, 0.4, 1, 0.0390122, 0.0785491, -0.0139432, 0.996049)
 tracks/3/type = "value"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("Claw/ClawSnap:playing")
+tracks/3/path = NodePath("ClawSnap:playing")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
@@ -369,6 +369,18 @@ tracks/3/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [true]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("ClawSwing/CollisionShape3D:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [false, true]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_2tw01"]
@@ -383,56 +395,56 @@ length = 0.1
 tracks/0/type = "rotation_3d"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("../Armature/Skeleton3D:Leg B Mid R")
+tracks/0/path = NodePath("../Skeleton3D:Leg B Mid R")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = PackedFloat32Array(0, 1, -0.140523, -0.0778563, -0.65408, 0.739169)
 tracks/1/type = "rotation_3d"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("../Armature/Skeleton3D:Leg A Mid R")
+tracks/1/path = NodePath("../Skeleton3D:Leg A Mid R")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = PackedFloat32Array(0, 1, -0.15453, 0.0278103, -0.656992, 0.737366)
 tracks/2/type = "rotation_3d"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("../Armature/Skeleton3D:Leg C Mid R")
+tracks/2/path = NodePath("../Skeleton3D:Leg C Mid R")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = PackedFloat32Array(0, 1, -0.137321, -0.223312, -0.619688, 0.739771)
 tracks/3/type = "rotation_3d"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("../Armature/Skeleton3D:Leg D Mid R")
+tracks/3/path = NodePath("../Skeleton3D:Leg D Mid R")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = PackedFloat32Array(0, 1, -0.143749, -0.358969, -0.552289, 0.738549)
 tracks/4/type = "rotation_3d"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("../Armature/Skeleton3D:Leg B Mid L")
+tracks/4/path = NodePath("../Skeleton3D:Leg B Mid L")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = PackedFloat32Array(0, 1, -0.0567131, 0.110258, 0.486863, 0.864634)
 tracks/5/type = "rotation_3d"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("../Armature/Skeleton3D:Leg A Mid L")
+tracks/5/path = NodePath("../Skeleton3D:Leg A Mid L")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = PackedFloat32Array(0, 1, -0.108454, 0.0730555, 0.49838, 0.85704)
 tracks/6/type = "rotation_3d"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("../Armature/Skeleton3D:Leg C Mid L")
+tracks/6/path = NodePath("../Skeleton3D:Leg C Mid L")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = PackedFloat32Array(0, 1, -0.0529675, 0.217181, 0.449471, 0.864871)
 tracks/7/type = "rotation_3d"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("../Armature/Skeleton3D:Leg D Mid L")
+tracks/7/path = NodePath("../Skeleton3D:Leg D Mid L")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = PackedFloat32Array(0, 1, -0.0525001, 0.259031, 0.422174, 0.86713)
@@ -444,56 +456,56 @@ loop_mode = 1
 tracks/0/type = "rotation_3d"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("../Armature/Skeleton3D:Leg B Mid R")
+tracks/0/path = NodePath("../Skeleton3D:Leg B Mid R")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = PackedFloat32Array(0, 1, -0.140523, -0.0778563, -0.65408, 0.739169, 0.0333333, 1, -0.140523, -0.0778563, -0.65408, 0.739169, 0.0666667, 1, -0.133024, -0.0913437, -0.627855, 0.761419, 0.1, 1, -0.116125, -0.12012, -0.567971, 0.805912, 0.166667, 1, -0.0656283, -0.195078, -0.38359, 0.900276, 0.2, 1, -0.0538711, -0.21049, -0.339656, 0.91511, 0.233333, 1, -0.0567936, -0.206725, -0.35061, 0.911654, 0.266667, 1, -0.0701259, -0.188993, -0.400303, 0.893936, 0.3, 1, -0.0895699, -0.161414, -0.471931, 0.862093, 0.333333, 1, -0.111087, -0.128305, -0.54992, 0.817793, 0.366667, 1, -0.128097, -0.0999549, -0.610506, 0.775166, 0.4, 1, -0.137232, -0.0838343, -0.642597, 0.749138, 0.416667, 1, -0.140523, -0.0778563, -0.65408, 0.739169)
 tracks/1/type = "rotation_3d"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("../Armature/Skeleton3D:Leg A Mid R")
+tracks/1/path = NodePath("../Skeleton3D:Leg A Mid R")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = PackedFloat32Array(0, 1, -0.15453, 0.0278103, -0.656992, 0.737366, 0.0333333, 1, -0.15453, 0.0278103, -0.656992, 0.737366, 0.0666667, 1, -0.151864, 0.00340187, -0.635895, 0.756679, 0.1, 1, -0.145345, -0.0494987, -0.587083, 0.794832, 0.166667, 1, -0.122375, -0.193242, -0.43248, 0.872149, 0.2, 1, -0.116381, -0.224058, -0.394869, 0.883364, 0.233333, 1, -0.117892, -0.216484, -0.40427, 0.880796, 0.266667, 1, -0.124607, -0.181207, -0.446717, 0.867226, 0.3, 1, -0.133858, -0.127527, -0.507264, 0.841726, 0.333333, 1, -0.143276, -0.0647578, -0.572214, 0.804891, 0.366667, 1, -0.150034, -0.0123085, -0.62184, 0.76854, 0.4, 1, -0.153378, 0.0170213, -0.647778, 0.746036, 0.416667, 1, -0.15453, 0.0278103, -0.656992, 0.737366)
 tracks/2/type = "rotation_3d"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("../Armature/Skeleton3D:Leg C Mid R")
+tracks/2/path = NodePath("../Skeleton3D:Leg C Mid R")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = PackedFloat32Array(0, 1, -0.137321, -0.223312, -0.619688, 0.739771, 0.0333333, 1, -0.137321, -0.223312, -0.619688, 0.739771, 0.0666667, 1, -0.129724, -0.23054, -0.591098, 0.761988, 0.1, 1, -0.112634, -0.245075, -0.526268, 0.806408, 0.166667, 1, -0.0617282, -0.276535, -0.329735, 0.900551, 0.2, 1, -0.0499069, -0.281646, -0.283458, 0.915334, 0.233333, 1, -0.0528444, -0.280447, -0.294978, 0.911891, 0.266667, 1, -0.0662533, -0.274374, -0.347389, 0.894232, 0.3, 1, -0.085835, -0.263654, -0.423391, 0.862473, 0.333333, 1, -0.107544, -0.24898, -0.506837, 0.818267, 0.366667, 1, -0.124739, -0.235018, -0.572254, 0.775714, 0.4, 1, -0.133986, -0.226548, -0.607154, 0.749726, 0.416667, 1, -0.137321, -0.223312, -0.619688, 0.739771)
 tracks/3/type = "rotation_3d"
 tracks/3/imported = false
 tracks/3/enabled = true
-tracks/3/path = NodePath("../Armature/Skeleton3D:Leg D Mid R")
+tracks/3/path = NodePath("../Skeleton3D:Leg D Mid R")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = PackedFloat32Array(0, 1, -0.143749, -0.358969, -0.552289, 0.738549, 0.0333333, 1, -0.143749, -0.358969, -0.552289, 0.738549, 0.0666667, 1, -0.135033, -0.349101, -0.526877, 0.763083, 0.1, 1, -0.115491, -0.326017, -0.469249, 0.812514, 0.166667, 1, -0.0577469, -0.251224, -0.294497, 0.92023, 0.2, 1, -0.0444231, -0.232735, -0.253339, 0.937913, 0.233333, 1, -0.0477312, -0.237366, -0.263585, 0.933757, 0.266667, 1, -0.0628551, -0.258196, -0.310197, 0.912777, 0.3, 1, -0.0850137, -0.287672, -0.377782, 0.875956, 0.333333, 1, -0.109688, -0.318925, -0.451974, 0.825818, 0.366667, 1, -0.129323, -0.342488, -0.510128, 0.778297, 0.4, 1, -0.13992, -0.354668, -0.541148, 0.749527, 0.416667, 1, -0.143749, -0.358969, -0.552289, 0.738549)
 tracks/4/type = "rotation_3d"
 tracks/4/imported = false
 tracks/4/enabled = true
-tracks/4/path = NodePath("../Armature/Skeleton3D:Leg B Mid L")
+tracks/4/path = NodePath("../Skeleton3D:Leg B Mid L")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = PackedFloat32Array(0, 1, -0.0567131, 0.110258, 0.486863, 0.864634, 0.0333333, 1, -0.0567131, 0.110258, 0.486863, 0.864634, 0.0666667, 1, -0.0647236, 0.107453, 0.503671, 0.85474, 0.1, 1, -0.0817959, 0.101277, 0.538932, 0.832229, 0.166667, 1, -0.127865, 0.0832035, 0.630106, 0.761376, 0.2, 1, -0.138005, 0.0789338, 0.64935, 0.743686, 0.233333, 1, -0.135494, 0.0800015, 0.644613, 0.748141, 0.266667, 1, -0.123996, 0.0848038, 0.622683, 0.767919, 0.3, 1, -0.10673, 0.0917574, 0.58902, 0.795767, 0.333333, 1, -0.086728, 0.0994413, 0.548974, 0.825359, 0.366667, 1, -0.0698347, 0.105632, 0.514308, 0.848205, 0.4, 1, -0.060267, 0.109021, 0.49434, 0.860297, 0.416667, 1, -0.0567131, 0.110258, 0.486863, 0.864634)
 tracks/5/type = "rotation_3d"
 tracks/5/imported = false
 tracks/5/enabled = true
-tracks/5/path = NodePath("../Armature/Skeleton3D:Leg A Mid L")
+tracks/5/path = NodePath("../Skeleton3D:Leg A Mid L")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = PackedFloat32Array(0, 1, -0.108454, 0.0730555, 0.49838, 0.85704, 0.0333333, 1, -0.108454, 0.0730555, 0.49838, 0.85704, 0.0666667, 1, -0.113029, 0.0637271, 0.514404, 0.847674, 0.1, 1, -0.122662, 0.0436339, 0.547968, 0.826306, 0.166667, 1, -0.147836, -0.0120913, 0.634378, 0.758658, 0.2, 1, -0.153207, -0.0246687, 0.652535, 0.741699, 0.233333, 1, -0.151883, -0.0215429, 0.648069, 0.745972, 0.266667, 1, -0.145771, -0.00732333, 0.627365, 0.764925, 0.3, 1, -0.136441, 0.0137544, 0.595512, 0.791556, 0.333333, 1, -0.125416, 0.0377745, 0.557513, 0.81977, 0.366667, 1, -0.11593, 0.057742, 0.524537, 0.841479, 0.4, 1, -0.110488, 0.0689247, 0.50551, 0.852937, 0.416667, 1, -0.108454, 0.0730555, 0.49838, 0.85704)
 tracks/6/type = "rotation_3d"
 tracks/6/imported = false
 tracks/6/enabled = true
-tracks/6/path = NodePath("../Armature/Skeleton3D:Leg C Mid L")
+tracks/6/path = NodePath("../Skeleton3D:Leg C Mid L")
 tracks/6/interp = 1
 tracks/6/loop_wrap = true
 tracks/6/keys = PackedFloat32Array(0, 1, -0.0529675, 0.217181, 0.449471, 0.864871, 0.0333333, 1, -0.0529675, 0.217181, 0.449471, 0.864871, 0.0666667, 1, -0.0610208, 0.218238, 0.466479, 0.855012, 0.1, 1, -0.0781904, 0.22017, 0.502225, 0.832575, 0.166667, 1, -0.124566, 0.223117, 0.595127, 0.761923, 0.2, 1, -0.134783, 0.223296, 0.614837, 0.744277, 0.233333, 1, -0.132253, 0.223268, 0.609982, 0.748721, 0.266667, 1, -0.120669, 0.223002, 0.587533, 0.768449, 0.3, 1, -0.103282, 0.222188, 0.55317, 0.796222, 0.333333, 1, -0.0831523, 0.220646, 0.512423, 0.825726, 0.366667, 1, -0.0661602, 0.218862, 0.477253, 0.8485, 0.4, 1, -0.0565402, 0.217661, 0.457035, 0.86055, 0.416667, 1, -0.0529675, 0.217181, 0.449471, 0.864871)
 tracks/7/type = "rotation_3d"
 tracks/7/imported = false
 tracks/7/enabled = true
-tracks/7/path = NodePath("../Armature/Skeleton3D:Leg D Mid L")
+tracks/7/path = NodePath("../Skeleton3D:Leg D Mid L")
 tracks/7/interp = 1
 tracks/7/loop_wrap = true
 tracks/7/keys = PackedFloat32Array(0, 1, -0.0525001, 0.259031, 0.422174, 0.86713, 0.0333333, 1, -0.0525001, 0.259031, 0.422174, 0.86713, 0.0666667, 1, -0.0612012, 0.269006, 0.435349, 0.856949, 0.1, 1, -0.0797589, 0.289978, 0.462925, 0.833818, 0.166667, 1, -0.129935, 0.344532, 0.533783, 0.761242, 0.2, 1, -0.141, 0.356118, 0.548643, 0.743163, 0.233333, 1, -0.138259, 0.353263, 0.544989, 0.747714, 0.266667, 1, -0.125716, 0.34007, 0.528041, 0.767933, 0.3, 1, -0.106897, 0.319884, 0.501939, 0.796432, 0.333333, 1, -0.0851238, 0.295962, 0.470763, 0.826766, 0.366667, 1, -0.066755, 0.275326, 0.443677, 0.85023, 0.4, 1, -0.0563599, 0.263467, 0.428038, 0.862666, 0.416667, 1, -0.0525001, 0.259031, 0.422174, 0.86713)
@@ -509,59 +521,7 @@ radius = 1.097
 height = 4.94
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_cqx6n"]
-size = Vector3(4.94407, 1, 6.24687)
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_i51v7"]
-transparency = 1
-albedo_color = Color(0.607843, 0.101961, 0.0862745, 0.541176)
-
-[sub_resource type="BoxMesh" id="BoxMesh_u12sy"]
-material = SubResource("StandardMaterial3D_i51v7")
-
-[sub_resource type="Animation" id="Animation_xidhu"]
-resource_name = "Swing"
-length = 0.3
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("TestingBlock:transparency")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.1, 0.2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [1.0, 0.0, 1.0]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath(".:position")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.1),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0, 0, 0)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath(".:scale")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.1001, 0.2),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector3(0.1, 0.1, 0.1), Vector3(1.04, 1.04, 1.04), Vector3(0.1, 0.1, 0.1)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_cbt8q"]
-_data = {
-"Swing": SubResource("Animation_xidhu")
-}
+size = Vector3(22.9004, 21.9872, 30.0685)
 
 [node name="Crazoonga" type="CharacterBody3D" groups=["player"]]
 transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
@@ -573,47 +533,32 @@ floor_stop_on_slope = false
 script = ExtResource("1_na1ic")
 metadata/_edit_group_ = true
 
-[node name="Collider" type="CollisionShape3D" parent="."]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(-1, -1.50996e-07, 6.60024e-15, 0, -4.37114e-08, -1, 1.50996e-07, -1, 4.37114e-08, 0, 0.115627, 0)
 shape = SubResource("CapsuleShape3D_8p8dy")
 
-[node name="Crazoonga" type="Node3D" parent="."]
-transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, 0)
-
-[node name="Shell_A" type="Node3D" parent="Crazoonga"]
-transform = Transform3D(-4.47941e-08, 0, 1.02477, 0, 1.02477, 0, -1.02477, 0, -4.47941e-08, 0.0100994, -0.109092, 0.000470401)
-visible = false
-
-[node name="Shell A" type="MeshInstance3D" parent="Crazoonga/Shell_A"]
-transform = Transform3D(1, 0, 0, 0, 0.999408, 0.0344045, 0, -0.0344045, 0.999408, 0, 0, 0)
+[node name="ShellA" type="MeshInstance3D" parent="."]
+transform = Transform3D(-1.02477, 3.08224e-09, -8.95352e-08, 0, 1.02416, 0.0352567, 8.95882e-08, 0.0352567, -1.02416, 0.000470401, -0.109092, -0.0100994)
 material_override = SubResource("StandardMaterial3D_pvtk6")
 mesh = SubResource("ArrayMesh_urblv")
 skeleton = NodePath("")
 
-[node name="Shell_B" type="Node3D" parent="Crazoonga"]
-transform = Transform3D(-4.47941e-08, 0, 1.02477, 0, 1.02477, 0, -1.02477, 0, -4.47941e-08, 0.0100994, -0.109092, 0.000470401)
-visible = false
-
-[node name="Shell B" type="MeshInstance3D" parent="Crazoonga/Shell_B"]
-transform = Transform3D(1, 0, 0, 0, 0.999408, 0.0344045, 0, -0.0344045, 0.999408, 0, 0, 0)
+[node name="ShellB" type="MeshInstance3D" parent="."]
+transform = Transform3D(-1.02477, 3.08224e-09, -8.95352e-08, 0, 1.02416, 0.0352567, 8.95882e-08, 0.0352567, -1.02416, 0.000470401, -0.109092, -0.0100994)
 material_override = SubResource("StandardMaterial3D_pvtk6")
 material_overlay = SubResource("StandardMaterial3D_e7ulv")
 mesh = SubResource("ArrayMesh_urblv")
 skeleton = NodePath("")
 
-[node name="Shell_C" type="Node3D" parent="Crazoonga"]
-transform = Transform3D(-4.47941e-08, 0, 1.02477, 0, 1.02477, 0, -1.02477, 0, -4.47941e-08, 0.0100994, -0.109092, 0.000470401)
-
-[node name="Shell C" type="MeshInstance3D" parent="Crazoonga/Shell_C"]
-transform = Transform3D(1, 0, 0, 0, 0.999408, 0.0344045, 0, -0.0344045, 0.999408, 0, 0, 0)
+[node name="ShellC" type="MeshInstance3D" parent="."]
+transform = Transform3D(-1.02477, 3.08224e-09, -8.95352e-08, 0, 1.02416, 0.0352567, 8.95882e-08, 0.0352567, -1.02416, 0.000470401, -0.109092, -0.0100994)
 material_override = SubResource("StandardMaterial3D_nen0o")
 material_overlay = SubResource("StandardMaterial3D_k0q2u")
 mesh = SubResource("ArrayMesh_4em7i")
 skeleton = NodePath("")
 
-[node name="Armature" type="Node3D" parent="Crazoonga"]
-
-[node name="Skeleton3D" type="Skeleton3D" parent="Crazoonga/Armature"]
+[node name="Skeleton3D" type="Skeleton3D" parent="."]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, 0)
 bones/0/name = "base"
 bones/0/parent = -1
 bones/0/rest = Transform3D(5.96046e-08, 0, -1, 0.825986, 0.563691, 8.9407e-08, 0.563691, -0.825986, 0, 0, 0, 0)
@@ -930,64 +875,50 @@ bones/44/position = Vector3(2.91857e-08, 0.561381, 3.26852e-08)
 bones/44/rotation = Quaternion(0.0103838, -6.03994e-14, -6.64312e-09, 0.999946)
 bones/44/scale = Vector3(1, 1, 1)
 
-[node name="Cube" type="MeshInstance3D" parent="Crazoonga/Armature/Skeleton3D"]
+[node name="Cube" type="MeshInstance3D" parent="Skeleton3D"]
 mesh = SubResource("ArrayMesh_u6h2n")
 skin = SubResource("Skin_62ukt")
 
-[node name="Claw" type="AnimationPlayer" parent="Crazoonga"]
+[node name="Claw" type="AnimationPlayer" parent="."]
 autoplay = "Default"
 libraries = {
 "": SubResource("AnimationLibrary_2tw01")
 }
 
-[node name="ClawSnap" type="AudioStreamPlayer" parent="Crazoonga/Claw"]
-stream = ExtResource("2_abk3g")
-
-[node name="Legs" type="AnimationPlayer" parent="Crazoonga"]
+[node name="Legs" type="AnimationPlayer" parent="."]
 root_node = NodePath("../Claw")
 autoplay = "Idle"
 libraries = {
 "": SubResource("AnimationLibrary_s3ur6")
 }
 
+[node name="ClawSnap" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("2_abk3g")
+
 [node name="CrazoongaArea3D" type="Area3D" parent="."]
 collision_layer = 0
-collision_mask = 8
+collision_mask = 24
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="CrazoongaArea3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.116, 0)
 shape = SubResource("CapsuleShape3D_24vg4")
 
 [node name="ClawSwing" type="Area3D" parent="."]
-transform = Transform3D(1.04905, 0, 0, 0, 1.04905, 0, 0, 0, 1.04905, 0, 0, 0)
-visible = false
+transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0)
 collision_layer = 4
 collision_mask = 0
 
-[node name="SwingTrigger" type="CollisionShape3D" parent="ClawSwing"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.30171, 0, 1.72088)
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ClawSwing"]
+transform = Transform3D(0.945246, -2.19004e-08, 0.32636, 2.12631e-08, 1, 5.52019e-09, -0.32636, 1.72148e-09, 0.945246, 27.6966, 16.529, 3.86751)
 shape = SubResource("BoxShape3D_cqx6n")
-
-[node name="SwingTimer" type="Timer" parent="ClawSwing"]
-wait_time = 0.5
-one_shot = true
-
-[node name="TestingBlock" type="MeshInstance3D" parent="ClawSwing"]
-transform = Transform3D(4.84874, 0, -5.68434e-14, 0, 1, 0, -5.68434e-14, 0, 6.02876, 2.30291, 0, 1.72464)
-visible = false
-mesh = SubResource("BoxMesh_u12sy")
-
-[node name="Swing" type="AnimationPlayer" parent="ClawSwing"]
-libraries = {
-"": SubResource("AnimationLibrary_cbt8q")
-}
+disabled = true
 
 [node name="Knockback" type="Timer" parent="."]
 process_callback = 0
 wait_time = 0.3
 one_shot = true
 
-[connection signal="animation_finished" from="Crazoonga/Claw" to="." method="_on_claw_animation_finished"]
-[connection signal="area_entered" from="CrazoongaArea3D" to="." method="_on_damage_taken"]
-[connection signal="body_entered" from="CrazoongaArea3D" to="." method="_on_damage_taken"]
-[connection signal="timeout" from="ClawSwing/SwingTimer" to="." method="_on_swing_timer_timeout"]
+[connection signal="ready" from="." to="." method="show_shells"]
+[connection signal="animation_finished" from="Claw" to="." method="_on_claw_animation_finished"]
+[connection signal="area_entered" from="CrazoongaArea3D" to="." method="_on_contact"]
+[connection signal="body_entered" from="CrazoongaArea3D" to="." method="_on_contact"]

--- a/SideStep Crazoonga Hours/Scenes/singleton.tscn
+++ b/SideStep Crazoonga Hours/Scenes/singleton.tscn
@@ -1,6 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://dkfc1hnl57rcg"]
-
-[ext_resource type="Script" path="res://Scripts/Singleton.gd" id="1_7fj2d"]
-
-[node name="Singleton" type="Node3D"]
-script = ExtResource("1_7fj2d")

--- a/SideStep Crazoonga Hours/Scripts/Pickup.gd
+++ b/SideStep Crazoonga Hours/Scripts/Pickup.gd
@@ -1,14 +1,5 @@
 extends Node3D
 
-signal checkShells
+func picked_up():
+	queue_free()
 
-var crazoonga: NodePath
-
-
-
-func _on_area_3d_body_entered(_body):
-	if Singleton.shellCount < 3:
-		Singleton.shellCount += 1
-		emit_signal("checkShells")
-		print(Singleton.shellCount)
-		queue_free()

--- a/SideStep Crazoonga Hours/Scripts/Singleton.gd
+++ b/SideStep Crazoonga Hours/Scripts/Singleton.gd
@@ -1,8 +1,0 @@
-extends Node3D
-
-var shellCount = 0
-
-
-func ShellCountIncrement():
-	shellCount += 1
-	emit_signal("CheckShells(Singleton.shellCount)")

--- a/SideStep Crazoonga Hours/project.godot
+++ b/SideStep Crazoonga Hours/project.godot
@@ -15,10 +15,6 @@ run/main_scene="res://Scenes/Crab Testing.tscn"
 config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://icon.svg"
 
-[autoload]
-
-Singleton="*res://Scenes/singleton.tscn"
-
 [display]
 
 window/stretch/mode="viewport"


### PR DESCRIPTION
This PR adds multiple improvements to Crazoonga, and its handling of shells.

## Unified Hurtboxes
There used to be two hurtboxes, one for collecting shells and another one for hazards. I decided to unify the two. There now needs to be a higher order function that manages contact, and decides to pick up the shell or to take damage, but an `Area3D` and a `CollisionShape3D` are saved. This change is up to style, but I believe it's a good one.

## Claw Animation
The claw animation now not only moves the claw, but also activates and deactivates the claw hitbox. This also fixed a bug where moving the crab to the lobster without moving the claw would damage him.

## Scene Tree Hierarchy
| Before | After |
|--------|-------|
| ![Screenshot from 2023-09-29 22-04-17](https://github.com/EggnogBaileys/TD-SideStep-CrazoongaHours/assets/90345171/0bdc18e9-a685-4cba-92a8-4af546e38361) | ![image](https://github.com/EggnogBaileys/TD-SideStep-CrazoongaHours/assets/90345171/252f8e23-4818-4c1d-b09d-e5c74ece821e) |
* Removed useless `Node3D` nodes. Most nodes already inherit `Node3D` anyway.
* Gave the entire role of animating the claw to `Claw`, as `Swing` and `SwingTimer` were redundant.
* Removed TestingBlock, as you can enable collision shapes if need be in the `Debug` tag.
* `CollisionShape3D` can keep their default name, as only their parent node's names matter.
* Renamed all nodes to PascalCase, as per the [Godot guide style](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html).

## Shell Management
The shell count is Crazoonga's, and not anyone else's. I thought that it woudl be better practice to move this to Cragzoonga's script. Since the `Area3D` hurtbox of Crazoonga returns the node that was touched, Crazoonga can now communicate with the shell. Meaning that no "picked up" signal is necessary, and a simple function call can be made.

To cycle the shell, instead of checking each one and setting their visibility to their respective count, this PR opts to hide all of them by mapping a hiding function (added comment explaining this), and to use a `match` statement to to match the shell count (which is now an enum) to the right `Node3D.show()` function. This way of doing it might be overkill in this small project, but it allows for a removal of magic numbers, enables easy error checking, and is easily expandable. This is the way I would do it in a big game.

Singleton was handling the shell count of Crazoonga, which is not requested by any other scene or node. Meaning that this feature can be localized, and emitted as a signal if need be. The signal has been implemented on Crazoonga, though nothing needs to connect to it as of now.

> **Note:** a singleton does not need to be in a scene. There only needs to be one GDScript saved on disk. The singleton needs to be of type Node, and can have children. The subtype of Node, and their children need to be setup by code.